### PR TITLE
Implement scanner config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,11 @@ add_executable(asioscan
         # --------------------------------------------------------
         # CLI parsing (add files here later)
         # src/cli/cli_parser.cpp
-        src/cli/cli_parser.hpp
+        # src/cli/cli_parser.hpp
         #
         # Scan configuration
         # src/config/scan_config.cpp
-        # src/config/scan_config.hpp
+        src/config/scan_config.hpp
         #
         # Scanner engine (Boost.Asio logic)
         # src/scanner/scanner.cpp

--- a/src/config/scan_config.hpp
+++ b/src/config/scan_config.hpp
@@ -1,6 +1,163 @@
+#pragma once
 
+/*
+ * ScanConfig
+ * ----------
+ * Immutable, data-only configuration describing a single port scan.
+ *
+ * This struct represents a fully validated snapshot of user intent,
+ * produced by the CLI parsing layer and consumed by the scanner and
+ * formatter layers.
+ *
+ * ScanConfig is the single source of truth for how a scan should run.
+ */
 
-#ifndef ASIOSCAN_SCAN_CONFIG_HPP
-#define ASIOSCAN_SCAN_CONFIG_HPP
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
 
-#endif //ASIOSCAN_SCAN_CONFIG_HPP
+namespace asioscan {
+
+/*
+ * Preferred IP version for outgoing connections.
+ * Auto allows the resolver / OS to choose.
+ */
+enum class IpVersion {
+    Auto,
+    IPv4,
+    IPv6
+};
+
+/*
+ * Output format for scan results.
+ */
+enum class OutputFormat {
+    Text,
+    Xml
+};
+
+/*
+ * Terminal color behavior.
+ * Auto enables color only when stdout is a TTY.
+ */
+enum class ColorMode {
+    Auto,
+    Always,
+    Never
+};
+
+/*
+ * ScanConfig
+ * ----------
+ * Data-only structure describing what scan to perform and how.
+ *
+ * Immutability is enforced by convention: the config is built once
+ * and passed as const& throughout the system.
+ */
+struct ScanConfig {
+    /* ------------------------------------------------------------
+     * Target selection
+     * ------------------------------------------------------------ */
+
+    // List of target hostnames or IP addresses to scan.
+    // These are provided as strings to remain independent of DNS
+    // resolution and networking libraries.
+    std::vector<std::string> targets{};
+
+    /* ------------------------------------------------------------
+     * Port selection
+     * ------------------------------------------------------------ */
+
+    // Canonical list of TCP ports to scan.
+    // All ranges, service names, and files should already be
+    // expanded by the CLI layer before constructing this config.
+    std::vector<std::uint16_t> ports{};
+
+    // Human-readable description of how ports were selected.
+    // Example: "top 100 common ports", "ports 1-1024"
+    std::string port_description{};
+
+    /* ------------------------------------------------------------
+     * Timing & performance
+     * ------------------------------------------------------------ */
+
+    // Per-port timeout for connection attempts.
+    // Default: 500 milliseconds.
+    std::chrono::milliseconds timeout{500};
+
+    // Maximum number of concurrent in-flight connection attempts.
+    std::size_t max_concurrency{200};
+
+    // Optional rate limit (connections per second).
+    // Not required for v1, but reserved for future use.
+    std::optional<std::size_t> rate_limit{};
+
+    /* ------------------------------------------------------------
+     * Network behavior
+     * ------------------------------------------------------------ */
+
+    // Preferred IP version (IPv4 / IPv6 / Auto).
+    IpVersion ip_version{IpVersion::Auto};
+
+    /* ------------------------------------------------------------
+     * Output behavior
+     * ------------------------------------------------------------ */
+
+    // Output format for results.
+    OutputFormat output_format{OutputFormat::Text};
+
+    // Optional output file path.
+    // If empty, results are written to stdout.
+    std::optional<std::string> output_file{};
+
+    // Enable verbose progress output (stderr).
+    bool verbose{false};
+
+    // Quiet mode: suppress headers and summaries.
+    bool quiet{false};
+
+    // Include connection reason in output (e.g., timeout, refused).
+    bool show_reason{false};
+
+    // Terminal color behavior.
+    ColorMode color_mode{ColorMode::Auto};
+
+    /* ------------------------------------------------------------
+     * Metadata
+     * ------------------------------------------------------------ */
+
+    // Program version string (e.g., "0.1.0").
+    std::string program_version{};
+
+    // Time at which the scan was initiated.
+    std::chrono::steady_clock::time_point start_time{};
+
+    /* ------------------------------------------------------------
+     * Lightweight semantic helpers
+     * ------------------------------------------------------------ */
+
+    // Returns true if exactly one target is being scanned.
+    bool is_single_host() const noexcept {
+        return targets.size() == 1;
+    }
+
+    // Returns true if multiple targets are being scanned.
+    bool is_multi_host() const noexcept {
+        return targets.size() > 1;
+    }
+
+    // Returns true if output is directed to a file.
+    bool has_output_file() const noexcept {
+        return output_file.has_value();
+    }
+
+    // Returns true if quiet mode is enabled.
+    bool is_quiet_mode() const noexcept {
+        return quiet;
+    }
+};
+
+} // namespace asioscan

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,31 +1,8 @@
+#include "config/scan_config.hpp"
 #include <boost/asio.hpp>
-#include <iostream>
 
 int main() {
-    try {
-        std::cout << "AsioScan: Boost.Asio smoke test starting...\n";
 
-        boost::asio::io_context io;
-
-        boost::asio::steady_timer timer(io);
-        timer.expires_after(std::chrono::seconds(1));
-
-        timer.async_wait([](const boost::system::error_code& ec) {
-            if (!ec) {
-                std::cout << "Timer fired successfully.\n";
-            } else {
-                std::cerr << "Timer error: " << ec.message() << "\n";
-            }
-        });
-
-        io.run();
-
-        std::cout << "AsioScan: Boost.Asio smoke test completed.\n";
-    }
-    catch (const std::exception& e) {
-        std::cerr << "Exception: " << e.what() << "\n";
-        return 1;
-    }
 
     return 0;
 }


### PR DESCRIPTION
This pull request introduces a new immutable configuration structure for describing port scans and integrates it into the build and main source files. The main focus is on adding the `ScanConfig` data structure, which centralizes scan configuration and metadata, and preparing the codebase to use it.

**Scan configuration infrastructure:**

* Added a new header file `src/config/scan_config.hpp` defining the `asioscan::ScanConfig` struct, which encapsulates all user-configurable scan parameters, output options, and metadata. This includes enums for IP version, output format, and color mode, as well as semantic helper methods.
* Updated `CMakeLists.txt` to properly include `src/config/scan_config.hpp` in the build, ensuring it is available throughout the project.

**Codebase integration:**

* Included the new `scan_config.hpp` header in `src/main.cpp` as the first step toward integrating the configuration system into the application's entry point.
* Removed the previous Boost.Asio smoke test logic from `src/main.cpp`, preparing the file for new logic that will use the configuration system.