### PR TITLE
Integrate CLI11 and add basic CLI parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,19 @@ else()
 endif()
 
 # ------------------------------------------------------------
+# CLI11 (command-line parsing, header-only)
+# ------------------------------------------------------------
+include(FetchContent)
+
+FetchContent_Declare(
+    CLI11
+    GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
+    GIT_TAG        v2.4.2
+)
+
+FetchContent_MakeAvailable(CLI11)
+
+# ------------------------------------------------------------
 # Main executable
 # ------------------------------------------------------------
 add_executable(asioscan
@@ -86,6 +99,11 @@ else()
         Boost::boost   # headers-only target (this exists on Homebrew)
     )
 endif()
+
+# ------------------------------------------------------------
+# CLI11 linkage (header-only)
+# ------------------------------------------------------------
+target_link_libraries(asioscan PRIVATE CLI11::CLI11)
 
 # ------------------------------------------------------------
 # Windows-specific networking requirement

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "result/host_result.hpp"
 #include "result/port_result.hpp"
 
+#include <CLI/CLI.hpp>
 #include <chrono>
 #include <iostream>
 #include <string>
@@ -17,8 +18,22 @@
 
 using namespace asioscan;
 
-int main() {
+int main(int argc, char** argv) {
     try {
+        // Quick CLI11 smoke test
+        CLI::App app{"AsioScan - TCP port scanner"};
+        
+        std::string target = "localhost";
+        app.add_option("-t,--target", target, "Target host");
+        
+        try {
+            app.parse(argc, argv);
+        } catch (const CLI::ParseError& e) {
+            return app.exit(e);
+        }
+        
+        std::cout << "CLI11 OK - target: " << target << "\n\n";
+
         // Create scan summary with multiple hosts
         ScanSummary summary;
         


### PR DESCRIPTION
Fetch CLI11 v2.4.2 via CMake FetchContent, make it available and link the CLI11::CLI11 target to the asioscan executable. Include <CLI/CLI.hpp> and change main to accept argc/argv, adding a small CLI11 smoke test: define -t/--target (default "localhost"), parse args with error handling, and print the parsed target. This wires up header-only CLI support and demonstrates basic command-line parsing without changing scanner logic.