### PR TITLE
Integrate catch2 Tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,33 +1,25 @@
 cmake_minimum_required(VERSION 3.16)
 
-# ------------------------------------------------------------
 # Project definition
-# ------------------------------------------------------------
 project(AsioScan
         VERSION 0.1.0
         DESCRIPTION "Cross-platform TCP port scanner using Boost.Asio"
         LANGUAGES CXX
 )
 
-# ------------------------------------------------------------
-# C++ standard (portable and strict)
-# ------------------------------------------------------------
+# C++ standard
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# ------------------------------------------------------------
 # Compiler warnings
-# ------------------------------------------------------------
 if (MSVC)
     add_compile_options(/W4)
 else()
     add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# ------------------------------------------------------------
-# CLI11 (command-line parsing, header-only)
-# ------------------------------------------------------------
+# CLI11 (header-only)
 include(FetchContent)
 
 FetchContent_Declare(
@@ -38,85 +30,75 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(CLI11)
 
-# ------------------------------------------------------------
-# Main executable
-# ------------------------------------------------------------
-add_executable(asioscan
-        src/main.cpp
+# Catch2 (unit test framework)
+FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG        v3.7.1
+)
 
-        # Configuration / models
+FetchContent_MakeAvailable(Catch2)
+
+# Core library (scanner + parser + formatter)
+add_library(asioscan_lib
         src/config/scan_config.hpp
-        #
-        # Scanner engine (Boost.Asio logic)
-        src/scanner/scanner.cpp
-        src/scanner/scanner.hpp
-        #
-        # Result models
         src/result/port_result.hpp
         src/result/host_result.hpp
         src/result/scan_summary.hpp
-        #
-        # Formatting
-        src/formatters/formatter.hpp
+        src/scanner/scanner.hpp
+        src/scanner/scanner.cpp
         src/formatters/OutputOptions.hpp
-        src/formatters/text_formatter.cpp
+        src/formatters/formatter.hpp
         src/formatters/text_formatter.hpp
-
+        src/formatters/text_formatter.cpp
 )
 
-# ------------------------------------------------------------
-# Include directories
-# ------------------------------------------------------------
-target_include_directories(asioscan
-        PRIVATE
+# Public headers for app and future tests
+target_include_directories(asioscan_lib
+        PUBLIC
         src
 )
 
-# ------------------------------------------------------------
-# Boost (correct cross-platform handling)
-#
-# Windows (vcpkg):
-#   - Uses FindBoost module
-#   - Requires explicit Boost.System linkage
-#
-# macOS (Homebrew):
-#   - Uses BoostConfig.cmake
-#   - Does NOT export Boost::system
-#   - Asio is header-only; system library is resolved implicitly
-# ------------------------------------------------------------
+# Boost (cross-platform)
 if (WIN32)
     find_package(Boost REQUIRED COMPONENTS system)
 
-    target_link_libraries(asioscan
-        PRIVATE
+    target_link_libraries(asioscan_lib
+        PUBLIC
         Boost::system
     )
 else()
     find_package(Boost CONFIG REQUIRED)
 
-    target_link_libraries(asioscan
-        PRIVATE
+    target_link_libraries(asioscan_lib
+        PUBLIC
         Boost::boost   # headers-only target (this exists on Homebrew)
     )
 endif()
 
-# ------------------------------------------------------------
-# CLI11 linkage (header-only)
-# ------------------------------------------------------------
-target_link_libraries(asioscan PRIVATE CLI11::CLI11)
+# CLI11 is used by the CLI parser implementation
+target_link_libraries(asioscan_lib PRIVATE CLI11::CLI11)
 
-# ------------------------------------------------------------
-# Windows-specific networking requirement
-# ------------------------------------------------------------
+# Windows networking requirement
 if (WIN32)
-    target_link_libraries(asioscan PRIVATE ws2_32)
+    target_link_libraries(asioscan_lib PUBLIC ws2_32)
 endif()
 
-# ------------------------------------------------------------
-# Ensure console subsystem on Windows
-# ------------------------------------------------------------
+# Thin executable entry point
+add_executable(asioscan src/main.cpp)
+target_link_libraries(asioscan PRIVATE asioscan_lib CLI11::CLI11)
+
+# Keep console subsystem on Windows
 if (WIN32)
     set_target_properties(asioscan PROPERTIES
         WIN32_EXECUTABLE FALSE
     )
 endif()
+
+# Enable CTest and add test targets
+enable_testing()
+
+# Catch2 test discovery helpers (Catch.cmake)
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
+
+add_subdirectory(tests)

--- a/tests/formatters/output_options_tests.cpp
+++ b/tests/formatters/output_options_tests.cpp
@@ -1,0 +1,33 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "formatters/OutputOptions.hpp"
+
+TEST_CASE("OutputOptions defaults are stable", "[formatter][options]") {
+    const asioscan::OutputOptions options;
+
+    REQUIRE(options.format == asioscan::OutputFormat::Text);
+    REQUIRE(options.text_mode == asioscan::TextMode::Normal);
+    REQUIRE_FALSE(options.output_file.has_value());
+    REQUIRE_FALSE(options.verbose);
+    REQUIRE_FALSE(options.show_reason);
+    REQUIRE(options.color_mode == asioscan::ColorMode::Auto);
+}
+
+TEST_CASE("OutputOptions can be configured explicitly", "[formatter][options]") {
+    asioscan::OutputOptions options;
+
+    options.format = asioscan::OutputFormat::Json;
+    options.text_mode = asioscan::TextMode::Quiet;
+    options.output_file = std::string{"results.txt"};
+    options.verbose = true;
+    options.show_reason = true;
+    options.color_mode = asioscan::ColorMode::Never;
+
+    REQUIRE(options.format == asioscan::OutputFormat::Json);
+    REQUIRE(options.text_mode == asioscan::TextMode::Quiet);
+    REQUIRE(options.output_file.has_value());
+    REQUIRE(options.output_file.value() == "results.txt");
+    REQUIRE(options.verbose);
+    REQUIRE(options.show_reason);
+    REQUIRE(options.color_mode == asioscan::ColorMode::Never);
+}

--- a/tests/formatters/text_formatter_tests.cpp
+++ b/tests/formatters/text_formatter_tests.cpp
@@ -1,0 +1,121 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "formatters/text_formatter.hpp"
+#include "formatters/OutputOptions.hpp"
+#include "result/scan_summary.hpp"
+#include "result/host_result.hpp"
+#include "result/port_result.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+class StdoutCapture {
+public:
+    StdoutCapture() : old_buf_(std::cout.rdbuf(stream_.rdbuf())) {}
+
+    ~StdoutCapture() {
+        std::cout.rdbuf(old_buf_);
+    }
+
+    std::string str() const {
+        return stream_.str();
+    }
+
+private:
+    std::ostringstream stream_;
+    std::streambuf* old_buf_;
+};
+
+asioscan::PortResult make_port(
+    std::uint16_t port,
+    asioscan::PortState state,
+    std::chrono::milliseconds latency,
+    std::string reason
+) {
+    asioscan::PortResult result;
+    result.port = port;
+    result.state = state;
+    result.latency = latency;
+    result.reason = std::move(reason);
+    return result;
+}
+
+asioscan::ScanSummary make_sample_summary() {
+    asioscan::ScanSummary summary;
+
+    const auto start = std::chrono::steady_clock::now();
+    summary.start_time = start;
+
+    asioscan::HostResult host;
+    host.host = "scanme.nmap.org";
+    host.start_time = start;
+    host.ports = {
+        make_port(22, asioscan::PortState::Open, std::chrono::milliseconds{10}, "Connection established"),
+        make_port(80, asioscan::PortState::Closed, std::chrono::milliseconds{5}, "Connection refused"),
+        make_port(443, asioscan::PortState::Open, std::chrono::milliseconds{12}, "Connection established")
+    };
+    host.end_time = start + std::chrono::milliseconds{20};
+
+    summary.hosts.push_back(host);
+    summary.end_time = start + std::chrono::milliseconds{25};
+
+    return summary;
+}
+
+} // namespace
+
+TEST_CASE("TextFormatter normal mode prints report structure and key fields", "[formatter][text][normal]") {
+    const auto summary = make_sample_summary();
+
+    asioscan::OutputOptions options;
+    options.text_mode = asioscan::TextMode::Normal;
+    options.show_reason = false;
+
+    asioscan::TextFormatter formatter;
+
+    StdoutCapture capture;
+    formatter.print(summary, options);
+    const std::string output = capture.str();
+
+    REQUIRE(output.find("AsioScan Scan Report") != std::string::npos);
+    REQUIRE(output.find("Host: scanme.nmap.org") != std::string::npos);
+    REQUIRE(output.find("PORT") != std::string::npos);
+    REQUIRE(output.find("STATE") != std::string::npos);
+
+    REQUIRE(output.find("22") != std::string::npos);
+    REQUIRE(output.find("80") != std::string::npos);
+    REQUIRE(output.find("443") != std::string::npos);
+    REQUIRE(output.find("Open") != std::string::npos);
+    REQUIRE(output.find("Closed") != std::string::npos);
+
+    REQUIRE(output.find("Scan Summary") != std::string::npos);
+    REQUIRE(output.find("Hosts scanned: 1") != std::string::npos);
+    REQUIRE(output.find("Open ports:    2") != std::string::npos);
+
+    REQUIRE(output.find("Connection established") == std::string::npos);
+}
+
+TEST_CASE("TextFormatter quiet mode prints only open ports in script-friendly format", "[formatter][text][quiet]") {
+    const auto summary = make_sample_summary();
+
+    asioscan::OutputOptions options;
+    options.text_mode = asioscan::TextMode::Quiet;
+
+    asioscan::TextFormatter formatter;
+
+    StdoutCapture capture;
+    formatter.print(summary, options);
+    const std::string output = capture.str();
+
+    REQUIRE(output.find("scanme.nmap.org:22 open") != std::string::npos);
+    REQUIRE(output.find("scanme.nmap.org:443 open") != std::string::npos);
+
+    REQUIRE(output.find("scanme.nmap.org:80 open") == std::string::npos);
+    REQUIRE(output.find("AsioScan Scan Report") == std::string::npos);
+    REQUIRE(output.find("Scan Summary") == std::string::npos);
+    REQUIRE(output.find("Host:") == std::string::npos);
+}

--- a/tests/formatters/text_formatter_tests.cpp
+++ b/tests/formatters/text_formatter_tests.cpp
@@ -66,6 +66,31 @@ asioscan::ScanSummary make_sample_summary() {
     return summary;
 }
 
+asioscan::ScanSummary make_hosts_only_summary() {
+    asioscan::ScanSummary summary;
+
+    const auto start = std::chrono::steady_clock::now();
+    summary.start_time = start;
+
+    asioscan::HostResult up_host;
+    up_host.host = "up.example";
+    up_host.start_time = start;
+    up_host.ports = {
+        make_port(22, asioscan::PortState::Open, std::chrono::milliseconds{10}, "Connection established")
+    };
+    up_host.end_time = start + std::chrono::milliseconds{10};
+
+    asioscan::HostResult down_host;
+    down_host.host = "down.example";
+    down_host.start_time = start;
+    down_host.end_time = start + std::chrono::milliseconds{10};
+
+    summary.hosts = {up_host, down_host};
+    summary.end_time = start + std::chrono::milliseconds{15};
+
+    return summary;
+}
+
 } // namespace
 
 TEST_CASE("TextFormatter normal mode prints report structure and key fields", "[formatter][text][normal]") {
@@ -118,4 +143,103 @@ TEST_CASE("TextFormatter quiet mode prints only open ports in script-friendly fo
     REQUIRE(output.find("AsioScan Scan Report") == std::string::npos);
     REQUIRE(output.find("Scan Summary") == std::string::npos);
     REQUIRE(output.find("Host:") == std::string::npos);
+}
+
+TEST_CASE("TextFormatter normal mode shows reasons when requested", "[formatter][text][normal]") {
+    const auto summary = make_sample_summary();
+
+    asioscan::OutputOptions options;
+    options.text_mode = asioscan::TextMode::Normal;
+    options.show_reason = true;
+
+    asioscan::TextFormatter formatter;
+
+    StdoutCapture capture;
+    formatter.print(summary, options);
+    const std::string output = capture.str();
+
+    REQUIRE(output.find("REASON") != std::string::npos);
+    REQUIRE(output.find("Connection established") != std::string::npos);
+    REQUIRE(output.find("Connection refused") != std::string::npos);
+}
+
+TEST_CASE("TextFormatter summary mode emits high-level counters only", "[formatter][text][summary]") {
+    const auto summary = make_sample_summary();
+
+    asioscan::OutputOptions options;
+    options.text_mode = asioscan::TextMode::Summary;
+
+    asioscan::TextFormatter formatter;
+
+    StdoutCapture capture;
+    formatter.print(summary, options);
+    const std::string output = capture.str();
+
+    REQUIRE(output.find("Hosts scanned: 1") != std::string::npos);
+    REQUIRE(output.find("Ports scanned: 3") != std::string::npos);
+    REQUIRE(output.find("Open ports: 2") != std::string::npos);
+
+    REQUIRE(output.find("AsioScan Scan Report") == std::string::npos);
+    REQUIRE(output.find("Host: scanme.nmap.org") == std::string::npos);
+    REQUIRE(output.find("PORT") == std::string::npos);
+}
+
+TEST_CASE("TextFormatter ports-only mode prints per-host port lines", "[formatter][text][ports-only]") {
+    const auto summary = make_sample_summary();
+
+    asioscan::OutputOptions options;
+    options.text_mode = asioscan::TextMode::PortsOnly;
+
+    asioscan::TextFormatter formatter;
+
+    StdoutCapture capture;
+    formatter.print(summary, options);
+    const std::string output = capture.str();
+
+    REQUIRE(output.find("Host: scanme.nmap.org") != std::string::npos);
+    REQUIRE(output.find("22/tcp open") != std::string::npos);
+    REQUIRE(output.find("80/tcp closed") != std::string::npos);
+    REQUIRE(output.find("443/tcp open") != std::string::npos);
+
+    REQUIRE(output.find("AsioScan Scan Report") == std::string::npos);
+    REQUIRE(output.find("Scan Summary") == std::string::npos);
+}
+
+TEST_CASE("TextFormatter hosts-only mode prints host status lines", "[formatter][text][hosts-only]") {
+    const auto summary = make_hosts_only_summary();
+
+    asioscan::OutputOptions options;
+    options.text_mode = asioscan::TextMode::HostsOnly;
+
+    asioscan::TextFormatter formatter;
+
+    StdoutCapture capture;
+    formatter.print(summary, options);
+    const std::string output = capture.str();
+
+    REQUIRE(output.find("up.example: up (1 open port)") != std::string::npos);
+    REQUIRE(output.find("down.example: down (0 open ports)") != std::string::npos);
+
+    REQUIRE(output.find("PORT") == std::string::npos);
+    REQUIRE(output.find("AsioScan Scan Report") == std::string::npos);
+}
+
+TEST_CASE("TextFormatter verbose mode includes latency, reason, and attempts", "[formatter][text][verbose]") {
+    const auto summary = make_sample_summary();
+
+    asioscan::OutputOptions options;
+    options.text_mode = asioscan::TextMode::Verbose;
+    options.show_reason = false;
+
+    asioscan::TextFormatter formatter;
+
+    StdoutCapture capture;
+    formatter.print(summary, options);
+    const std::string output = capture.str();
+
+    REQUIRE(output.find("LATENCY(ms)") != std::string::npos);
+    REQUIRE(output.find("REASON") != std::string::npos);
+    REQUIRE(output.find("Attempts: 1") != std::string::npos);
+    REQUIRE(output.find("Connection established") != std::string::npos);
+    REQUIRE(output.find("Connection refused") != std::string::npos);
 }

--- a/tests/result/test_host_result.cpp
+++ b/tests/result/test_host_result.cpp
@@ -1,0 +1,60 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "result/host_result.hpp"
+
+#include <chrono>
+
+namespace {
+
+asioscan::PortResult make_port(std::uint16_t port, asioscan::PortState state) {
+    asioscan::PortResult result;
+    result.port = port;
+    result.state = state;
+    return result;
+}
+
+} // namespace
+
+TEST_CASE("HostResult defaults to an empty host result", "[result][host]") {
+    const asioscan::HostResult host;
+
+    REQUIRE(host.host.empty());
+    REQUIRE(host.ports.empty());
+    REQUIRE(host.total_ports() == 0);
+    REQUIRE(host.open_ports() == 0);
+    REQUIRE(host.closed_ports() == 0);
+    REQUIRE(host.filtered_ports() == 0);
+    REQUIRE(host.error_ports() == 0);
+}
+
+TEST_CASE("HostResult aggregates per-port state counts", "[result][host]") {
+    asioscan::HostResult host;
+    host.host = "scanme.nmap.org";
+    host.ports = {
+        make_port(22, asioscan::PortState::Open),
+        make_port(80, asioscan::PortState::Closed),
+        make_port(443, asioscan::PortState::Open),
+        make_port(8080, asioscan::PortState::Filtered),
+        make_port(3306, asioscan::PortState::Error)
+    };
+
+    REQUIRE(host.host == "scanme.nmap.org");
+    REQUIRE(host.total_ports() == 5);
+    REQUIRE(host.open_ports() == 2);
+    REQUIRE(host.closed_ports() == 1);
+    REQUIRE(host.filtered_ports() == 1);
+    REQUIRE(host.error_ports() == 1);
+
+    REQUIRE(host.open_ports() + host.closed_ports() + host.filtered_ports() + host.error_ports()
+            == host.total_ports());
+}
+
+TEST_CASE("HostResult duration is derived from start and end timestamps", "[result][host]") {
+    asioscan::HostResult host;
+
+    const auto start = std::chrono::steady_clock::now();
+    host.start_time = start;
+    host.end_time = start + std::chrono::milliseconds{125};
+
+    REQUIRE(host.duration() == std::chrono::milliseconds{125});
+}

--- a/tests/result/test_port_result.cpp
+++ b/tests/result/test_port_result.cpp
@@ -1,0 +1,53 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "result/port_result.hpp"
+
+#include <chrono>
+
+TEST_CASE("PortResult default construction is predictable", "[result][port]") {
+    const asioscan::PortResult result;
+
+    REQUIRE(result.port == 0);
+    REQUIRE(result.state == asioscan::PortState::Error);
+    REQUIRE(result.latency == std::chrono::milliseconds{0});
+    REQUIRE(result.reason.empty());
+
+    REQUIRE_FALSE(result.is_open());
+    REQUIRE_FALSE(result.is_closed());
+    REQUIRE_FALSE(result.is_filtered());
+    REQUIRE(result.is_error());
+}
+
+TEST_CASE("PortResult reflects assigned fields and state helpers", "[result][port]") {
+    asioscan::PortResult result;
+
+    SECTION("Open state") {
+        result.port = 443;
+        result.state = asioscan::PortState::Open;
+        result.latency = std::chrono::milliseconds{42};
+        result.reason = "Connection established";
+
+        REQUIRE(result.port == 443);
+        REQUIRE(result.latency.count() == 42);
+        REQUIRE(result.reason == "Connection established");
+        REQUIRE(result.is_open());
+    }
+
+    SECTION("Closed state") {
+        result.state = asioscan::PortState::Closed;
+
+        REQUIRE(result.is_closed());
+        REQUIRE_FALSE(result.is_open());
+        REQUIRE_FALSE(result.is_filtered());
+        REQUIRE_FALSE(result.is_error());
+    }
+
+    SECTION("Filtered state") {
+        result.state = asioscan::PortState::Filtered;
+
+        REQUIRE(result.is_filtered());
+        REQUIRE_FALSE(result.is_open());
+        REQUIRE_FALSE(result.is_closed());
+        REQUIRE_FALSE(result.is_error());
+    }
+}

--- a/tests/result/test_scan_summary.cpp
+++ b/tests/result/test_scan_summary.cpp
@@ -1,0 +1,69 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "result/scan_summary.hpp"
+
+#include <chrono>
+
+namespace {
+
+asioscan::HostResult make_host(
+    const char* name,
+    std::initializer_list<asioscan::PortState> states
+) {
+    asioscan::HostResult host;
+    host.host = name;
+
+    std::uint16_t port = 1000;
+    for (const auto state : states) {
+        asioscan::PortResult result;
+        result.port = port++;
+        result.state = state;
+        host.ports.push_back(result);
+    }
+
+    return host;
+}
+
+} // namespace
+
+TEST_CASE("ScanSummary defaults to an empty summary", "[result][summary]") {
+    const asioscan::ScanSummary summary;
+
+    REQUIRE_FALSE(summary.config.has_value());
+    REQUIRE(summary.hosts.empty());
+    REQUIRE(summary.total_hosts() == 0);
+    REQUIRE(summary.total_ports() == 0);
+    REQUIRE(summary.total_open_ports() == 0);
+    REQUIRE(summary.hosts_up() == 0);
+    REQUIRE(summary.hosts_down() == 0);
+    REQUIRE_FALSE(summary.has_errors());
+}
+
+TEST_CASE("ScanSummary aggregates host-level counts consistently", "[result][summary]") {
+    asioscan::ScanSummary summary;
+    summary.hosts = {
+        make_host("host-a", {asioscan::PortState::Open, asioscan::PortState::Closed}),
+        make_host("host-b", {asioscan::PortState::Filtered, asioscan::PortState::Error}),
+        make_host("host-c", {asioscan::PortState::Open})
+    };
+
+    REQUIRE(summary.total_hosts() == 3);
+    REQUIRE(summary.total_ports() == 5);
+    REQUIRE(summary.total_open_ports() == 2);
+    REQUIRE(summary.hosts_up() == 2);
+    REQUIRE(summary.hosts_down() == 1);
+    REQUIRE(summary.has_errors());
+
+    REQUIRE(summary.hosts_up() + summary.hosts_down() == summary.total_hosts());
+    REQUIRE(summary.total_open_ports() <= summary.total_ports());
+}
+
+TEST_CASE("ScanSummary duration uses scan start and end timestamps", "[result][summary]") {
+    asioscan::ScanSummary summary;
+
+    const auto start = std::chrono::steady_clock::now();
+    summary.start_time = start;
+    summary.end_time = start + std::chrono::milliseconds{375};
+
+    REQUIRE(summary.duration() == std::chrono::milliseconds{375});
+}

--- a/tests/scanner/test_scanner_unit.cpp
+++ b/tests/scanner/test_scanner_unit.cpp
@@ -1,0 +1,58 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "scanner/scanner.hpp"
+
+#include <chrono>
+
+using Catch::Matchers::ContainsSubstring;
+
+namespace {
+
+asioscan::ScanConfig make_minimal_valid_config() {
+    asioscan::ScanConfig config;
+    config.targets = {"localhost"};
+    config.ports = {80};
+    config.timeout = std::chrono::milliseconds{250};
+    config.max_concurrency = 32;
+    return config;
+}
+
+} // namespace
+
+TEST_CASE("Scanner exposes an immutable config snapshot", "[scanner][unit]") {
+    const auto config = make_minimal_valid_config();
+    asioscan::Scanner scanner(config);
+
+    const auto& snapshot = scanner.config();
+
+    REQUIRE(snapshot.targets == config.targets);
+    REQUIRE(snapshot.ports == config.ports);
+    REQUIRE(snapshot.timeout == config.timeout);
+    REQUIRE(snapshot.max_concurrency == config.max_concurrency);
+}
+
+TEST_CASE("Scanner rejects missing targets before starting I/O", "[scanner][unit]") {
+    auto config = make_minimal_valid_config();
+    config.targets.clear();
+
+    asioscan::Scanner scanner(std::move(config));
+
+    REQUIRE_THROWS_WITH(scanner.run(), ContainsSubstring("No target hosts specified"));
+}
+
+TEST_CASE("Scanner rejects missing ports before starting I/O", "[scanner][unit]") {
+    auto config = make_minimal_valid_config();
+    config.ports.clear();
+
+    asioscan::Scanner scanner(std::move(config));
+
+    REQUIRE_THROWS_WITH(scanner.run(), ContainsSubstring("No ports specified"));
+}
+
+TEST_CASE("Scanner cancel is safe and idempotent before run", "[scanner][unit]") {
+    asioscan::Scanner scanner(make_minimal_valid_config());
+
+    REQUIRE_NOTHROW(scanner.cancel());
+    REQUIRE_NOTHROW(scanner.cancel());
+}

--- a/tests/test_smoke.cpp
+++ b/tests/test_smoke.cpp
@@ -1,5 +1,21 @@
 #include <catch2/catch_test_macros.hpp>
 
-TEST_CASE("AsioScan test infrastructure compiles", "[smoke]") {
-    SUCCEED();
+#include "result/port_result.hpp"
+
+TEST_CASE("PortResult stores scan outcome and exposes state helpers", "[smoke][result]") {
+    asioscan::PortResult result;
+
+    result.port = 443;
+    result.state = asioscan::PortState::Open;
+    result.latency = std::chrono::milliseconds(42);
+    result.reason = "Connection established";
+
+    REQUIRE(result.port == 443);
+    REQUIRE(result.latency.count() == 42);
+    REQUIRE(result.reason == "Connection established");
+
+    REQUIRE(result.is_open());
+    REQUIRE_FALSE(result.is_closed());
+    REQUIRE_FALSE(result.is_filtered());
+    REQUIRE_FALSE(result.is_error());
 }

--- a/tests/test_smoke.cpp
+++ b/tests/test_smoke.cpp
@@ -1,0 +1,5 @@
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("AsioScan test infrastructure compiles", "[smoke]") {
+    SUCCEED();
+}


### PR DESCRIPTION
This pull request introduces a comprehensive unit test suite for the core library components and refactors the CMake build system to support modular builds and automated testing. The changes modularize the codebase into a reusable library, add Catch2-based unit tests for key data structures and logic, and update the build configuration to simplify dependency management and enable test discovery.

**Build system refactoring and modularization:**

- Refactored `CMakeLists.txt` to create a reusable `asioscan_lib` library containing all core logic, with a thin `asioscan` executable as the entry point. Dependencies (Boost, CLI11, Catch2) are now handled more cleanly, and Windows-specific requirements are streamlined. CTest and Catch2 test discovery are enabled for automated test runs. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL3-R22) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL41-R104)

**Unit test suite additions:**

*Formatter and output options:*
- Added `tests/formatters/output_options_tests.cpp` to verify the default values and configurability of `OutputOptions`.
- Added `tests/formatters/text_formatter_tests.cpp` with comprehensive tests for all output modes of `TextFormatter`, ensuring correct formatting and content for normal, quiet, summary, ports-only, hosts-only, and verbose modes.

*Result models:*
- Added `tests/result/test_port_result.cpp` to validate construction and state helpers of `PortResult`.
- Added `tests/result/test_host_result.cpp` to check aggregation and duration logic in `HostResult`.
- Added `tests/result/test_scan_summary.cpp` to verify aggregation and duration in `ScanSummary`.

*Scanner engine:*
- Added `tests/scanner/test_scanner_unit.cpp` to test configuration validation, error handling, and safe cancellation in the `Scanner` class.

*Smoke test:*
- Added a basic smoke test in `tests/test_smoke.cpp` to ensure `PortResult` stores and exposes scan outcomes as expected.