### PR TITLE
Unignore CMakeLists and add tests CMakeLists for our Catch2 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,8 @@ logs/
 *.xml
 *.json
 *.txt
+!CMakeLists.txt
+!**/CMakeLists.txt
 
 # =====================================================
 # Dependency artifacts (Boost, vcpkg, Conan)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Test executable for AsioScan core library
+add_executable(asioscan_tests
+    test_smoke.cpp
+    cli/cli_parser_tests.cpp
+    result/test_port_result.cpp
+    result/test_host_result.cpp
+    result/test_scan_summary.cpp
+    formatters/text_formatter_tests.cpp
+    formatters/output_options_tests.cpp
+    scanner/test_scanner_unit.cpp
+)
+
+# Link production library and Catch2 test main
+target_link_libraries(asioscan_tests
+    PRIVATE
+    asioscan_lib
+    Catch2::Catch2WithMain
+)
+
+# Enable Catch2 test discovery with CTest
+include(Catch)
+catch_discover_tests(asioscan_tests)


### PR DESCRIPTION
Allow CMakeLists.txt files to be tracked by git (.gitignore updated to negate CMakeLists.txt and **/CMakeLists.txt). Add tests/CMakeLists.txt which defines an asioscan_tests executable with unit test sources, links asioscan_lib and Catch2::Catch2WithMain, and enables Catch2/CTest test discovery (catch_discover_tests). This enables building and running the project's test suite via CMake/CTest.