### PR TITLE
Migrate to standalone Asio and remove Boost dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 # Project definition
 project(AsioScan
         VERSION 0.1.0
-        DESCRIPTION "Cross-platform TCP port scanner using Boost.Asio"
+        DESCRIPTION "Cross-platform TCP port scanner using standalone Asio"
         LANGUAGES CXX
 )
 
@@ -79,7 +79,7 @@ if(NOT TARGET asio)
     target_include_directories(asio INTERFACE ${asio_SOURCE_DIR}/asio/include)
 endif()
 
-# We define ASIO_STANDALONE so it maps directly to std:: instead of boost::
+# We define ASIO_STANDALONE so it maps directly to std::instead of boost::
 target_compile_definitions(asioscan_lib PUBLIC ASIO_STANDALONE)
 
 target_link_libraries(asioscan_lib PUBLIC asio)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,22 +65,24 @@ target_include_directories(asioscan_lib
         src
 )
 
-# Boost (cross-platform)
-if (WIN32)
-    find_package(Boost REQUIRED COMPONENTS system)
+# Standalone Asio (cross-platform, header-only framework)
+FetchContent_Declare(
+    asio
+    GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
+    GIT_TAG        asio-1-30-2 # Latest stable tag
+)
+FetchContent_MakeAvailable(asio)
 
-    target_link_libraries(asioscan_lib
-        PUBLIC
-        Boost::system
-    )
-else()
-    find_package(Boost CONFIG REQUIRED)
-
-    target_link_libraries(asioscan_lib
-        PUBLIC
-        Boost::boost   # headers-only target (this exists on Homebrew)
-    )
+# Create an exact target if Asio's internal CMake changes don't provide one
+if(NOT TARGET asio)
+    add_library(asio INTERFACE)
+    target_include_directories(asio INTERFACE ${asio_SOURCE_DIR}/asio/include)
 endif()
+
+# We define ASIO_STANDALONE so it maps directly to std:: instead of boost::
+target_compile_definitions(asioscan_lib PUBLIC ASIO_STANDALONE)
+
+target_link_libraries(asioscan_lib PUBLIC asio)
 
 # CLI11 is used by the CLI parser implementation
 target_link_libraries(asioscan_lib PRIVATE CLI11::CLI11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ if(NOT TARGET asio)
     target_include_directories(asio INTERFACE ${asio_SOURCE_DIR}/asio/include)
 endif()
 
-# We define ASIO_STANDALONE so it maps directly to std::instead of boost::
+# We define ASIO_STANDALONE so it maps directly to std:: instead of boost::
 target_compile_definitions(asioscan_lib PUBLIC ASIO_STANDALONE)
 
 target_link_libraries(asioscan_lib PUBLIC asio)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AsioScan
 
-AsioScan is a fast, cross-platform TCP connect port scanner built with modern C++20 and **Boost.Asio**. It provides a clean, modular command-line interface for network exploration, offering both human-readable and machine-parseable outputs.
+AsioScan is a fast, cross-platform TCP connect port scanner built with modern C++20 and **standalone Asio**. It provides a clean, modular command-line interface for network exploration, offering both human-readable and machine-parseable outputs.
 
 ## Design Goals
 
-Designed with a focus on code readability and a modular architecture, AsioScan serves as both a practical networking utility and an educational reference implementation for asynchronous network operations using Boost.Asio.
+Designed with a focus on code readability and a modular architecture, AsioScan serves as both a practical networking utility and an educational reference implementation for asynchronous network operations using standalone Asio.
 
 ## Features
 
@@ -53,7 +53,7 @@ Total duration: 0.51s
 
 ## Development Guide
 
-The core logic, CLI parser, and network scanner are written predominantly in modern **C++20** and leverage **Boost.Asio** for high-performance TCP connect sweeping.
+The core logic, CLI parser, and network scanner are written predominantly in modern **C++20** and leverage **standalone Asio** for high-performance TCP connect sweeping.
 
 * **Build System:** CMake (3.16+)
 * **Testing:** Catch2 (via CTest)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ The core execution path of AsioScan follows a strict, unidirectional pipeline:
          v                             |
   +--------------+                     |
   |   Scanner    |                     |
-  | (Boost.Asio) |                     v
+  |    (Asio)    |                     v
   +--------------+             +---------------+
          |                     | Output Writer |
     ScanSummary  ------------> |  (Formatters) |
@@ -32,7 +32,7 @@ The core execution path of AsioScan follows a strict, unidirectional pipeline:
 
 1. **Input:** The user provides arguments via the command line.
 2. **Parsing:** The `cli_parser` processes these arguments, enforcing constraints and validating inputs. It outputs two detached configurations: a `ScanConfig` and an `OutputOptions`.
-3. **Execution:** The `Scanner` engine takes the immutable `ScanConfig`, connects to the network via `Boost.Asio`, and aggregates the results into a `ScanSummary`.
+3. **Execution:** The `Scanner` engine takes the immutable `ScanConfig`, connects to the network via `standalone Asio`, and aggregates the results into a `ScanSummary`.
 4. **Formatting:** The `output_writer` evaluates the `OutputOptions` to select a specific `Formatter` (Text or XML) and renders the `ScanSummary` to the specified output stream.
 
 ---
@@ -49,7 +49,7 @@ AsioScan uses simple, immutable (or strictly managed) data structures as interna
 *   **`ScanSummary`**: The final artifact of a scan run. It contains a list of `HostResult` objects, each of which contains a list of `PortResult` objects (detailing individual port states, latencies, and connection reasons).
 
 ### 3. Asynchronous Scanner (`src/scanner/`)
-The `Scanner` is the engine of AsioScan. It runs a single-threaded asynchronous task loop utilizing `Boost.Asio::io_context`.
+The `Scanner` is the engine of AsioScan. It runs a single-threaded asynchronous task loop utilizing `asio::io_context`.
 *   It dynamically bounds concurrency by maintaining a strict limit of in-flight connection attempts.
 *   It utilizes cooperative cancellation: if the user interrupts the program (`Ctrl+C`), the scanner stops scheduling new ports, drains the existing active connections, and gracefully returns a partial `ScanSummary`.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -8,7 +8,6 @@ To build AsioScan, your system must have the following tools installed:
 
 * **C++ Compiler**: A compiler supporting C++20 (e.g., GCC 10+, Clang 10+, or MSVC 2019+).
 * **CMake**: Version 3.16 or newer.
-* **Boost Libraries**: Specifically `Boost.Asio` and `Boost.System`. This must be installed on your system prior to building.
 
 ### Dependency Management
 
@@ -23,22 +22,17 @@ The build system automatically fetches and builds the following internal depende
 ### Linux (Debian/Ubuntu)
 ```bash
 sudo apt update
-sudo apt install build-essential cmake libboost-all-dev
+sudo apt install build-essential cmake
 ```
 
 ### macOS (Homebrew)
 ```bash
-brew install cmake boost
+brew install cmake
 ```
 
 ### Windows
 1. **Compiler**: Install Visual Studio (2019 or 2022) with the "Desktop development with C++" workload.
 2. **CMake**: Install via the Visual Studio Installer or download from [cmake.org](https://cmake.org/).
-3. **Boost**: The easiest way to get Boost on Windows is using [vcpkg](https://vcpkg.io/):
-   ```bash
-   vcpkg install boost-system:x64-windows
-   ```
-   *Note: Using vcpkg requires providing the toolchain file to CMake during configuration.*
 
 ---
 
@@ -59,10 +53,10 @@ brew install cmake boost
    cmake -DCMAKE_BUILD_TYPE=Release ..
    ```
 
-   *For Windows (using vcpkg):*
+   *For Windows:*
    ```powershell
    mkdir build && cd build
-   cmake .. -DCMAKE_TOOLCHAIN_FILE="C:\path\to\vcpkg\scripts\buildsystems\vcpkg.cmake"
+   cmake ..
    ```
 
 3. **Compile the project:**
@@ -111,4 +105,3 @@ Alternatively, you can invoke the Catch2 test runner directly for more granular 
 **Windows:**
 ```powershell
 .\tests\Release\asioscan_tests.exe
-```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,22 @@
 # AsioScan Documentation
 
-Welcome to the official documentation for **AsioScan**, a fast, cross-platform TCP connect port scanner. 
+Welcome to the AsioScan documentation. This hub contains comprehensive information regarding the design, usage, and development of AsioScan.
 
-This documentation is divided into organized sections to help users and developers understand, build, and use the tool effectively.
+## Contents
+
+* [Architecture](architecture.md) - Learn about the component isolation and core data flow.
+* [Building from Source](build.md) - Compiling with CMake, C++20, and standalone Asio.
+* [CLI Reference](cli.md) - Detailed command-line options and examples.
+* [Testing](testing.md) - Writing and running the test suite with Catch2.
+* [Releases](release.md) - Managing semantic versioning and release workflows.
 
 ## User Guide
 
 * [Quick Start](../README.md#usage) - Basic usage and examples.
-* [CLI Reference](cli.md) - Complete command-line arguments and flags.
 * [Output Formats](output-formats.md) - Details on Text, XML, and other supported machine-parseable outputs.
 
 ## Developer Guide
 
-* [Building from Source](build.md) - Compiling with CMake, C++20, and Boost.Asio.
 * [Testing](testing.md) - Test organization, framework details, and Catch2 execution.
 * [Architecture](architecture.md) - High-level design, data flow, concurrency model, and internals.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,7 +7,7 @@
 The primary distribution goal for AsioScan is to provide a frictionless experience for both end-users and developers. 
 To achieve this, the release process will focus on:
 * **Semantic Versioning**: Strict adherence to SemVer (vMAJOR.MINOR.PATCH) for predictable updates.
-* **Standalone Executables**: Providing cleanly compiled, ready-to-run binaries that do not require users to install heavy C++ toolchains or Boost libraries on their system.
+* **Standalone Executables**: Providing cleanly compiled, ready-to-run binaries that do not require users to install heavy C++ toolchains on their system.
 * **Automation**: Utilizing CI/CD pipelines to ensure tests run and binaries are deterministically built for every tag.
 
 ## Supported Target Platforms

--- a/src/scanner/scanner.cpp
+++ b/src/scanner/scanner.cpp
@@ -5,7 +5,7 @@
 #include <asio/steady_timer.hpp>
 #include <asio/connect.hpp>
 #include <asio/post.hpp>
-#include <system_error>
+#include <asio/error.hpp>
 
 #include <chrono>
 #include <stdexcept>
@@ -112,7 +112,7 @@ public:
         cancel_active_timers();
 
         // Ensure io_context exits if no operations are in-flight
-        asio::post(io_context_, [this]() {
+        asio::post(io_context_.get_executor(), [this]() {
             finalize_if_cancelled_and_idle();
         });
     }
@@ -212,12 +212,12 @@ private:
 
     void scan_port_async(const std::string& host, std::uint16_t port) {
         using asio::ip::tcp;
-        using std::error_code;
+        using asio::error_code;
 
         // Allocate per-operation resources
-        auto socket = std::make_shared<tcp::socket>(io_context_);
+        auto socket = std::make_shared<tcp::socket>(io_context_.get_executor());
         auto timer = std::make_shared<asio::steady_timer>(
-            io_context_,
+            io_context_.get_executor(),
             config_.timeout
         );
 
@@ -234,7 +234,7 @@ private:
         auto completed = std::make_shared<bool>(false);
 
         // Synchronous resolution (acceptable for v1; async in future)
-        tcp::resolver resolver(io_context_);
+        tcp::resolver resolver(io_context_.get_executor());
         error_code resolve_ec;
 
         auto endpoints = resolver.resolve(
@@ -310,7 +310,7 @@ private:
         );
     }
 
-    void classify_connect_result(const std::error_code& ec,
+    void classify_connect_result(const asio::error_code& ec,
                                   PortResult& result) {
         if (cancel_requested_ && ec == asio::error::operation_aborted) {
             result.state = PortState::Error;
@@ -399,7 +399,7 @@ private:
         }
 
         for (auto& socket : sockets) {
-            std::error_code ec;
+            asio::error_code ec;
             socket->cancel(ec);
         }
     }

--- a/src/scanner/scanner.cpp
+++ b/src/scanner/scanner.cpp
@@ -1,11 +1,11 @@
 #include "scanner/scanner.hpp"
 
-#include <boost/asio/io_context.hpp>
-#include <boost/asio/ip/tcp.hpp>
-#include <boost/asio/steady_timer.hpp>
-#include <boost/asio/connect.hpp>
-#include <boost/asio/post.hpp>
-#include <boost/system/error_code.hpp>
+#include <asio/io_context.hpp>
+#include <asio/ip/tcp.hpp>
+#include <asio/steady_timer.hpp>
+#include <asio/connect.hpp>
+#include <asio/post.hpp>
+#include <system_error>
 
 #include <chrono>
 #include <stdexcept>
@@ -112,7 +112,7 @@ public:
         cancel_active_timers();
 
         // Ensure io_context exits if no operations are in-flight
-        boost::asio::post(io_context_, [this]() {
+        asio::post(io_context_, [this]() {
             finalize_if_cancelled_and_idle();
         });
     }
@@ -211,12 +211,12 @@ private:
      */
 
     void scan_port_async(const std::string& host, std::uint16_t port) {
-        using boost::asio::ip::tcp;
-        using boost::system::error_code;
+        using asio::ip::tcp;
+        using std::error_code;
 
         // Allocate per-operation resources
         auto socket = std::make_shared<tcp::socket>(io_context_);
-        auto timer = std::make_shared<boost::asio::steady_timer>(
+        auto timer = std::make_shared<asio::steady_timer>(
             io_context_,
             config_.timeout
         );
@@ -252,7 +252,7 @@ private:
         }
 
         // Launch async connect
-        boost::asio::async_connect(
+        asio::async_connect(
             *socket,
             endpoints,
             [this, socket, timer, result, completed, start_time, host]
@@ -288,7 +288,7 @@ private:
                 *completed = true;
 
                 // Timer cancelled by connect success
-                if (ec == boost::asio::error::operation_aborted) {
+                if (ec == asio::error::operation_aborted) {
                     return;
                 }
 
@@ -310,18 +310,18 @@ private:
         );
     }
 
-    void classify_connect_result(const boost::system::error_code& ec,
+    void classify_connect_result(const std::error_code& ec,
                                   PortResult& result) {
-        if (cancel_requested_ && ec == boost::asio::error::operation_aborted) {
+        if (cancel_requested_ && ec == asio::error::operation_aborted) {
             result.state = PortState::Error;
             result.reason = "Cancelled";
         } else if (!ec) {
             result.state = PortState::Open;
             result.reason = "Connection established";
-        } else if (ec == boost::asio::error::connection_refused) {
+        } else if (ec == asio::error::connection_refused) {
             result.state = PortState::Closed;
             result.reason = "Connection refused";
-        } else if (ec == boost::asio::error::operation_aborted) {
+        } else if (ec == asio::error::operation_aborted) {
             result.state = PortState::Filtered;
             result.reason = "Timeout";
         } else {
@@ -389,7 +389,7 @@ private:
      */
 
     void cancel_active_sockets() {
-        std::vector<std::shared_ptr<boost::asio::ip::tcp::socket>> sockets;
+        std::vector<std::shared_ptr<asio::ip::tcp::socket>> sockets;
         sockets.reserve(active_sockets_.size());
 
         for (const auto& weak : active_sockets_) {
@@ -399,13 +399,13 @@ private:
         }
 
         for (auto& socket : sockets) {
-            boost::system::error_code ec;
+            std::error_code ec;
             socket->cancel(ec);
         }
     }
 
     void cancel_active_timers() {
-        std::vector<std::shared_ptr<boost::asio::steady_timer>> timers;
+        std::vector<std::shared_ptr<asio::steady_timer>> timers;
         timers.reserve(active_timers_.size());
 
         for (const auto& weak : active_timers_) {
@@ -470,11 +470,11 @@ private:
     std::vector<HostResult> completed_hosts_;
 
     // Active operation tracking for cancellation
-    std::vector<std::weak_ptr<boost::asio::ip::tcp::socket>> active_sockets_;
-    std::vector<std::weak_ptr<boost::asio::steady_timer>> active_timers_;
+    std::vector<std::weak_ptr<asio::ip::tcp::socket>> active_sockets_;
+    std::vector<std::weak_ptr<asio::steady_timer>> active_timers_;
 
     // Event loop
-    boost::asio::io_context io_context_;
+    asio::io_context io_context_;
 };
 
 /*

--- a/src/scanner/scanner.hpp
+++ b/src/scanner/scanner.hpp
@@ -117,7 +117,7 @@ public:
 
 private:
     class Impl;                     // Opaque implementation (defined in scanner.cpp)
-    std::unique_ptr<Impl> impl_;    // PIMPL to keep Boost.Asio out of the public header
+    std::unique_ptr<Impl> impl_;    // PIMPL to keep Asio out of the public header
 };
 
 } // namespace asioscan

--- a/tests/scanner/test_scanner_unit.cpp
+++ b/tests/scanner/test_scanner_unit.cpp
@@ -56,3 +56,90 @@ TEST_CASE("Scanner cancel is safe and idempotent before run", "[scanner][unit]")
     REQUIRE_NOTHROW(scanner.cancel());
     REQUIRE_NOTHROW(scanner.cancel());
 }
+
+TEST_CASE("Scanner natively handles Asio timeouts and operation aborts", "[scanner][integration][timeout]") {
+    // Relevance to Migration: Validates that `asio::steady_timer` appropriately races against 
+    // `asio::async_connect` and that the forced socket cancellation correctly translates 
+    // `asio::error::operation_aborted` through `std::error_code` into a Filtered state.
+    auto config = make_minimal_valid_config();
+    config.targets = {"192.0.2.1"}; // RFC 5737 TEST-NET-1 (non-routable blackhole)
+    config.ports = {80};
+    config.timeout = std::chrono::milliseconds{10}; // Extremely tight timeout
+
+    asioscan::Scanner scanner(std::move(config));
+    auto summary = scanner.run();
+
+    REQUIRE(summary.hosts.size() == 1);
+    REQUIRE(summary.hosts[0].ports.size() == 1);
+    
+    // We expect the 10ms timer to fire before TCP retries expire.
+    const auto& port = summary.hosts[0].ports[0];
+    REQUIRE(port.state == asioscan::PortState::Filtered);
+    REQUIRE_THAT(port.reason, ContainsSubstring("Timeout"));
+}
+
+TEST_CASE("Scanner natively translates OS connection refused", "[scanner][integration][error_code]") {
+    // Relevance to Migration: Validates that an OS-level ECONNREFUSED error natively maps into 
+    // `std::error_code` exactly as it did with `boost::system::error_code`, properly matching 
+    // the conditional branch `ec == asio::error::connection_refused`.
+    auto config = make_minimal_valid_config();
+    config.targets = {"127.0.0.1"};
+    config.ports = {54321}; // Extremely unlikely to have a service listening
+    config.timeout = std::chrono::milliseconds{5000}; 
+
+    asioscan::Scanner scanner(std::move(config));
+    auto summary = scanner.run();
+
+    REQUIRE(summary.hosts.size() == 1);
+    REQUIRE(summary.hosts[0].ports.size() == 1);
+
+    const auto& port = summary.hosts[0].ports[0];
+    // If it is genuinely closed, it should report connection refused explicitly
+    if (port.state == asioscan::PortState::Closed) {
+        REQUIRE_THAT(port.reason, ContainsSubstring("Connection refused"));
+    }
+}
+
+TEST_CASE("Scanner handles mid-scan cooperative cancellation securely", "[scanner][async][post]") {
+    // Relevance to Migration: The migration replaced `boost::asio::post` with standalone 
+    // `asio::post`. This test forces a callback queue injection mid-execution to verify the 
+    // single-threaded queue drains without deadlock and properly maps partial results.
+    auto config = make_minimal_valid_config();
+    // Use test-net IPs to hang the connections on purpose so we can cancel them before they timeout
+    config.targets = {"192.0.2.1", "192.0.2.2", "192.0.2.3"};
+    config.ports = {80, 443};
+    config.timeout = std::chrono::milliseconds{5000}; 
+
+    asioscan::ScannerCallbacks callbacks;
+    asioscan::Scanner* scanner_ptr = nullptr;
+    int ports_completed = 0;
+
+    callbacks.on_port_result = [&](const std::string&, const asioscan::PortResult&) {
+        ports_completed++;
+        if (ports_completed == 1 && scanner_ptr) {
+            scanner_ptr->cancel(); // Cancel on the first completed operation
+        }
+    };
+
+    asioscan::Scanner scanner(std::move(config), callbacks);
+    scanner_ptr = &scanner;
+
+    // Start a 5s block, but expect it to exit extremely fast due to early cancellation
+    auto start = std::chrono::steady_clock::now();
+    auto summary = scanner.run();
+    auto elapsed = std::chrono::steady_clock::now() - start;
+
+    REQUIRE(elapsed < std::chrono::milliseconds{3000}); // Proves it didn't wait the full 5000ms
+    REQUIRE(ports_completed > 0);
+    
+    // Remaining in-flight ports that were cancelled should map to Error/Cancelled
+    bool found_cancelled = false;
+    for (const auto& host : summary.hosts) {
+        for (const auto& p : host.ports) {
+            if (p.state == asioscan::PortState::Error && p.reason == "Cancelled") {
+                found_cancelled = true;
+            }
+        }
+    }
+    REQUIRE(found_cancelled);
+}


### PR DESCRIPTION
This pull request migrates AsioScan from using Boost.Asio to standalone Asio, streamlining dependencies and simplifying both the build process and project documentation. The most significant changes are the removal of Boost from the build and documentation, the integration of standalone Asio via CMake, and the refactoring of source code to use the new Asio API.

**Dependency and Build System Changes:**

* Replaced Boost.Asio with standalone Asio throughout the project. The build system now fetches standalone Asio using `FetchContent` in `CMakeLists.txt`, defines `ASIO_STANDALONE`, and removes all Boost-related configuration and linking. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL6-R6) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL68-R86)
* Updated build and installation instructions in `docs/build.md` to remove references to Boost, including dependency lists and platform-specific setup steps. [[1]](diffhunk://#diff-43453f510556d352276e897e137cb103b3bbca24acb6cba33208d4887b2e3c77L11) [[2]](diffhunk://#diff-43453f510556d352276e897e137cb103b3bbca24acb6cba33208d4887b2e3c77L26-L41) [[3]](diffhunk://#diff-43453f510556d352276e897e137cb103b3bbca24acb6cba33208d4887b2e3c77L62-R59) [[4]](diffhunk://#diff-43453f510556d352276e897e137cb103b3bbca24acb6cba33208d4887b2e3c77L114)

**Source Code Refactoring:**

* Refactored all scanner implementation code in `src/scanner/scanner.cpp` to use standalone Asio includes, types, and error handling instead of Boost.Asio equivalents. [[1]](diffhunk://#diff-54a1bb29c677cb5b43adb9891cd3a9800a35c72024e8e2502eba40ebaf17a644L3-R8) [[2]](diffhunk://#diff-54a1bb29c677cb5b43adb9891cd3a9800a35c72024e8e2502eba40ebaf17a644L115-R115) [[3]](diffhunk://#diff-54a1bb29c677cb5b43adb9891cd3a9800a35c72024e8e2502eba40ebaf17a644L214-R220) [[4]](diffhunk://#diff-54a1bb29c677cb5b43adb9891cd3a9800a35c72024e8e2502eba40ebaf17a644L237-R237) [[5]](diffhunk://#diff-54a1bb29c677cb5b43adb9891cd3a9800a35c72024e8e2502eba40ebaf17a644L255-R255) [[6]](diffhunk://#diff-54a1bb29c677cb5b43adb9891cd3a9800a35c72024e8e2502eba40ebaf17a644L291-R291) [[7]](diffhunk://#diff-54a1bb29c677cb5b43adb9891cd3a9800a35c72024e8e2502eba40ebaf17a644L313-R324) [[8]](diffhunk://#diff-54a1bb29c677cb5b43adb9891cd3a9800a35c72024e8e2502eba40ebaf17a644L392-R392) [[9]](diffhunk://#diff-54a1bb29c677cb5b43adb9891cd3a9800a35c72024e8e2502eba40ebaf17a644L402-R408) [[10]](diffhunk://#diff-54a1bb29c677cb5b43adb9891cd3a9800a35c72024e8e2502eba40ebaf17a644L473-R477)
* Updated the PIMPL comment in `scanner.hpp` to reference Asio instead of Boost.Asio.

**Documentation Updates:**

* Updated all documentation and README references from Boost.Asio to standalone Asio, including architectural diagrams and descriptive text. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R7) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L56-R56) [[3]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L23-R23) [[4]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L35-R35) [[5]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L52-R52)
* Revised the main documentation index and release notes to remove Boost mentions and clarify the use of standalone Asio. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L3-L15) [[2]](diffhunk://#diff-87479ac9ea16cec5ceafce00b3b049d7d5920cb663afae42901f20e7c4e6705dL10-R10)

These changes reduce external dependencies, simplify the build process for users and contributors, and clarify the project's architecture and requirements.