### PR TITLE
Close sockets on shutdown and update test targets for consistency

### DIFF
--- a/src/scanner/scanner.cpp
+++ b/src/scanner/scanner.cpp
@@ -400,7 +400,7 @@ private:
 
         for (auto& socket : sockets) {
             asio::error_code ec;
-            socket->cancel(ec);
+            socket->close(ec);
         }
     }
 

--- a/tests/scanner/test_scanner_unit.cpp
+++ b/tests/scanner/test_scanner_unit.cpp
@@ -106,7 +106,8 @@ TEST_CASE("Scanner handles mid-scan cooperative cancellation securely", "[scanne
     // single-threaded queue drains without deadlock and properly maps partial results.
     auto config = make_minimal_valid_config();
     // Use test-net IPs to hang the connections on purpose so we can cancel them before they timeout
-    config.targets = {"192.0.2.1", "192.0.2.2", "192.0.2.3"};
+    // Add localhost as the first target so it completes quickly and triggers cancellation on all platforms
+    config.targets = {"127.0.0.1", "192.0.2.1", "192.0.2.2", "192.0.2.3"};
     config.ports = {80, 443};
     config.timeout = std::chrono::milliseconds{5000}; 
 


### PR DESCRIPTION
Replace socket->cancel(ec) with socket->close(ec) to ensure sockets are properly closed during shutdown and avoid lingering async operations. Update the unit test to add 127.0.0.1 as the first target so a local connection completes quickly and triggers cooperative cancellation behavior consistently across platforms.