### PR TITLE
Enhance CI workflow with multi-OS support and CMake presets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,20 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      # Allow all OS builds to finish even if one platform fails
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - name: Check out the repository
+      - name: Checkout source code
         uses: actions/checkout@v4
 
-      - name: Configure CMake
+      - name: Configure project
         run: cmake --preset ${{ matrix.os }}
 
-      - name: Build the project
+      - name: Build project
         run: cmake --build --preset ${{ matrix.os }}
 
-      - name: Run tests with CTest
+      - name: Run tests
         run: ctest --preset ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,23 +5,23 @@ on:
   pull_request:
 
 jobs:
-     build-and-test:
-       name: Build and Test (${{ matrix.os }})
-       runs-on: ${{ matrix.os }}
-       strategy:
-         matrix:
-           os: [ubuntu-latest, windows-latest, macos-latest]
+  build-and-test:
+    name: Build and Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
 
-       steps:
-       - name: Check out the repository
-         uses: actions/checkout@v4
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
-       - name: Configure CMake
-         run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
 
-       - name: Build the project
-         run: cmake --build build --config Release
+      - name: Configure CMake
+        run: cmake --preset ${{ matrix.os }}
 
-       - name: Run tests with CTest
-         working-directory: build
-         run: ctest -C Release --output-on-failure
+      - name: Build the project
+        run: cmake --build --preset ${{ matrix.os }}
+
+      - name: Run tests with CTest
+        run: ctest --preset ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    name: Build and Test (Ubuntu)
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v4
+
+    - name: Install Ninja
+      run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+    - name: Configure CMake
+      run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build the project
+      run: cmake --build build --config Release
+
+    - name: Run tests with CTest
+      working-directory: build
+      run: ctest -C Release --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,19 +5,19 @@ on:
   pull_request:
 
 jobs:
-  build-and-test:
-    name: Build and Test (Ubuntu)
-    runs-on: ubuntu-latest
+build-and-test:
+  name: Build and Test (${{ matrix.os }})
+  runs-on: ${{ matrix.os }}
+  strategy:
+    matrix:
+      os: [ubuntu-latest, windows-latest, macos-latest]
 
-    steps:
-    - name: Check out the repository
-      uses: actions/checkout@v4
+  steps:
+  - name: Check out the repository
+    uses: actions/checkout@v4
 
-    - name: Install Ninja
-      run: sudo apt-get update && sudo apt-get install -y ninja-build
-
-    - name: Configure CMake
-      run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+  - name: Configure CMake
+    run: cmake -B build -DCMAKE_BUILD_TYPE=Release
 
     - name: Build the project
       run: cmake --build build --config Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,23 +5,23 @@ on:
   pull_request:
 
 jobs:
-build-and-test:
-  name: Build and Test (${{ matrix.os }})
-  runs-on: ${{ matrix.os }}
-  strategy:
-    matrix:
-      os: [ubuntu-latest, windows-latest, macos-latest]
+     build-and-test:
+       name: Build and Test (${{ matrix.os }})
+       runs-on: ${{ matrix.os }}
+       strategy:
+         matrix:
+           os: [ubuntu-latest, windows-latest, macos-latest]
 
-  steps:
-  - name: Check out the repository
-    uses: actions/checkout@v4
+       steps:
+       - name: Check out the repository
+         uses: actions/checkout@v4
 
-  - name: Configure CMake
-    run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+       - name: Configure CMake
+         run: cmake -B build -DCMAKE_BUILD_TYPE=Release
 
-    - name: Build the project
-      run: cmake --build build --config Release
+       - name: Build the project
+         run: cmake --build build --config Release
 
-    - name: Run tests with CTest
-      working-directory: build
-      run: ctest -C Release --output-on-failure
+       - name: Run tests with CTest
+         working-directory: build
+         run: ctest -C Release --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,8 @@ logs/
 *.txt
 !CMakeLists.txt
 !**/CMakeLists.txt
+!CMakePresets.json
+CMakeUserPresets.json
 
 # =====================================================
 # Dependency artifacts (Boost, vcpkg, Conan)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,9 @@ endif()
 # We define ASIO_STANDALONE so it maps directly to std:: instead of boost::
 target_compile_definitions(asioscan_lib PUBLIC ASIO_STANDALONE)
 
-target_link_libraries(asioscan_lib PUBLIC asio)
+# Asio relies on pthreads on Linux platforms
+find_package(Threads REQUIRED)
+target_link_libraries(asioscan_lib PUBLIC asio Threads::Threads)
 
 # CLI11 is used by the CLI parser implementation
 target_link_libraries(asioscan_lib PRIVATE CLI11::CLI11)
@@ -105,8 +107,5 @@ endif()
 
 # Enable CTest and add test targets
 enable_testing()
-
-# Catch2 test discovery helpers (Catch.cmake)
-list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 
 add_subdirectory(tests)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,45 +32,49 @@
   ],
   "buildPresets": [
     {
-      "name": "ubuntu-latest",
-      "configurePreset": "ubuntu-latest",
+      "name": "ci-build-base",
+      "hidden": true,
       "configuration": "Release"
+    },
+    {
+      "name": "ubuntu-latest",
+      "inherits": "ci-build-base",
+      "configurePreset": "ubuntu-latest"
     },
     {
       "name": "macos-latest",
-      "configurePreset": "macos-latest",
-      "configuration": "Release"
+      "inherits": "ci-build-base",
+      "configurePreset": "macos-latest"
     },
     {
       "name": "windows-latest",
-      "configurePreset": "windows-latest",
-      "configuration": "Release"
+      "inherits": "ci-build-base",
+      "configurePreset": "windows-latest"
     }
   ],
   "testPresets": [
     {
-      "name": "ubuntu-latest",
-      "configurePreset": "ubuntu-latest",
+      "name": "ci-test-base",
+      "hidden": true,
       "configuration": "Release",
       "output": {
         "outputOnFailure": true
       }
+    },
+    {
+      "name": "ubuntu-latest",
+      "inherits": "ci-test-base",
+      "configurePreset": "ubuntu-latest"
     },
     {
       "name": "macos-latest",
-      "configurePreset": "macos-latest",
-      "configuration": "Release",
-      "output": {
-        "outputOnFailure": true
-      }
+      "inherits": "ci-test-base",
+      "configurePreset": "macos-latest"
     },
     {
       "name": "windows-latest",
-      "configurePreset": "windows-latest",
-      "configuration": "Release",
-      "output": {
-        "outputOnFailure": true
-      }
+      "inherits": "ci-test-base",
+      "configurePreset": "windows-latest"
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,76 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "ci-base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "ubuntu-latest",
+      "inherits": "ci-base",
+      "generator": "Unix Makefiles"
+    },
+    {
+      "name": "macos-latest",
+      "inherits": "ci-base",
+      "generator": "Unix Makefiles"
+    },
+    {
+      "name": "windows-latest",
+      "inherits": "ci-base",
+      "generator": "Visual Studio 17 2022"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "ubuntu-latest",
+      "configurePreset": "ubuntu-latest",
+      "configuration": "Release"
+    },
+    {
+      "name": "macos-latest",
+      "configurePreset": "macos-latest",
+      "configuration": "Release"
+    },
+    {
+      "name": "windows-latest",
+      "configurePreset": "windows-latest",
+      "configuration": "Release"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "ubuntu-latest",
+      "configurePreset": "ubuntu-latest",
+      "configuration": "Release",
+      "output": {
+        "onFailure": true
+      }
+    },
+    {
+      "name": "macos-latest",
+      "configurePreset": "macos-latest",
+      "configuration": "Release",
+      "output": {
+        "onFailure": true
+      }
+    },
+    {
+      "name": "windows-latest",
+      "configurePreset": "windows-latest",
+      "configuration": "Release",
+      "output": {
+        "onFailure": true
+      }
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -53,7 +53,7 @@
       "configurePreset": "ubuntu-latest",
       "configuration": "Release",
       "output": {
-        "onFailure": true
+        "outputOnFailure": true
       }
     },
     {
@@ -61,7 +61,7 @@
       "configurePreset": "macos-latest",
       "configuration": "Release",
       "output": {
-        "onFailure": true
+        "outputOnFailure": true
       }
     },
     {
@@ -69,7 +69,7 @@
       "configurePreset": "windows-latest",
       "configuration": "Release",
       "output": {
-        "onFailure": true
+        "outputOnFailure": true
       }
     }
   ]


### PR DESCRIPTION
This pull request introduces a cross-platform continuous integration (CI) workflow and improves the CMake build configuration for better platform compatibility and automation. The main changes include adding a GitHub Actions workflow for building and testing on multiple operating systems, introducing CMake presets for standardized builds, and ensuring correct thread library linkage for Asio on Linux.

**CI/CD and Build Automation:**

* Added a new GitHub Actions workflow (`.github/workflows/ci.yml`) to automatically build and test the project on Ubuntu, macOS, and Windows using matrix builds. This ensures that the project is continuously tested across all major platforms.
* Introduced `CMakePresets.json` to define standardized configure, build, and test presets for each supported CI platform, streamlining local and CI builds.

**Build System Improvements:**

* Updated `CMakeLists.txt` to link the Asio library with the pthreads library on Linux by finding and linking `Threads::Threads`. This fixes potential threading issues on Unix-like systems.
* Simplified test setup in `CMakeLists.txt` by removing unused Catch2 test discovery helpers, as test configuration is now handled via presets and subdirectory inclusion.