### PR TITLE
Revamp README and build documentation with CI details and CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,46 @@
 # AsioScan
 
-AsioScan is a fast, cross-platform TCP connect port scanner built with modern C++20 and **standalone Asio**. It provides a clean, modular command-line interface for network exploration, offering both human-readable and machine-parseable outputs.
+![CI](https://github.com/trystanhenriques/AsioScan/actions/workflows/ci.yml/badge.svg)
 
-## Design Goals
+**AsioScan** is a lightning-fast, cross-platform TCP connect port scanner built using **Modern C++20** and **standalone Asio**. 
 
-Designed with a focus on code readability and a modular architecture, AsioScan serves as both a practical networking utility and an educational reference implementation for asynchronous network operations using standalone Asio.
-
-## Features
-
-* **TCP Connect Scanning:** Reliable, connection-based port discovery.
-* **Flexible Targeting:** Supports single-host and multi-host scans.
-* **Port Configuration:** Scan explicit port lists, ranges, or utilize common-port presets.
-* **Multiple Output Formats:** Standard console text for users, and XML for automated tool integration.
-* **Cross-Platform:** Native support for Windows, macOS, and Linux.
+Designed for high throughput, memory safety, and non-blocking I/O, AsioScan serves as a practical utility for network exploration and a robust example of asynchronous programming in C++.
 
 ---
 
-## Usage
+## Features
 
-### Quick Start
+* **TCP Connect Sweeping:** Reliable, RFC-compliant connection-based port discovery.
+* **Flexible Targeting:** Supports targeting single hosts or multiple IP/hostname resolutions concurrently.
+* **Granular Concurrency:** Explicit bounding of max in-flight connections to avoid exhausting OS file descriptor limits.
+* **Multiple Output Modes:** Output to standard text, quiet (script-friendly) mode, or full XML layouts for automated toolchains.
 
+For a deeper dive into the tool's non-blocking, single-threaded cooperative concurrency engine, see the [**Architecture Documentation**](docs/architecture.md).
+
+---
+
+## Quick Start
+
+AsioScan features a highly modular command-line interface powered by `CLI11`. 
+
+### Basic Usage
 ```bash
-asioscan 127.0.0.1 -p 80,443
+asioscan <targets> -p <ports> [options]
 ```
+```bash
+# Scan a single host on common web ports
+asioscan 127.0.0.1 -p 80,443
+
+# Sweep a broad range of ports aggressively
+asioscan scanme.nmap.org -p 1-10000 -c 500 -t 200
+```
+
+### Key CLI Options Preview
+* `-p, --ports` : Ports to scan (e.g., `80`, `22,80,443`, `1-1024`).
+* `-c, --concurrency` : Maximum concurrent async connections (default: `200`).
+* `-t, --timeout` : Per-port TCP connection timeout in milliseconds (default: `500`).
+* `-q, --quiet` : Script-friendly minimum output showing only open ports.
+* `--oX, --output-xml` : Write structured XML output to a file for automation.
 
 ### Example Output
 
@@ -49,31 +67,47 @@ Open ports:    0
 Total duration: 0.51s
 ```
 
----
-
-## Development Guide
-
-The core logic, CLI parser, and network scanner are written predominantly in modern **C++20** and leverage **standalone Asio** for high-performance TCP connect sweeping.
-
-* **Build System:** CMake (3.16+)
-* **Testing:** Catch2 (via CTest)
-
-Please refer to the [**Building from Source**](docs/build.md) and [**Testing**](docs/testing.md) guides for full prerequisites, library installation via your system's package manager, and exact compilation steps.
+For the complete list of options and output formatting flags, see the [**CLI Reference**](docs/cli.md).
 
 ---
 
-## Documentation
+## Build Instructions
 
-For comprehensive guides on usage, building, CLI references, and architecture, please visit the [**AsioScan Documentation Hub**](docs/index.md).
+AsioScan uses modern **CMake (3.20+)** and manages dependencies automatically via `FetchContent`. 
+
+We ship with standard `CMakePresets.json` configurations making building unified across OS environments (Linux, macOS, and Windows):
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/trystanhenriques/AsioScan.git
+cd AsioScan
+
+# 2. Configure for your OS (e.g., ubuntu-latest, macos-latest, or windows-latest)
+cmake --preset ubuntu-latest
+
+# 3. Build the project
+cmake --build --preset ubuntu-latest
+```
+
+For full system requirements and advanced toolchain details, see the [**Building Documentation**](docs/build.md).
 
 ---
 
-## Scope and Status
+## Testing & CI
 
-**Project Status:** *Experimental / Active Development*
-The project is currently establishing its foundation. Internal APIs, behavior, and output format structures are subject to change.
+This project maintains rigorous test coverage isolating the async engine, CLI parser bounds, OS state classifications, and formatter outputs using **Catch2 v3**.
 
-**Current Scope Limitations:**
-Presently, the focus is strictly on reliable TCP connect scanning. Advanced scan types (like SYN stealth scans, which require raw sockets and elevated privileges) are currently out of scope until the core architecture is fully stabilized.
+```bash
+# Run the test suite against the target preset
+ctest --preset ubuntu-latest
+```
+
+The repository is fully integrated with **GitHub Actions**, automatically validating builds and running tests across all major operating systems. 
+
+For more details on the testing framework and test organization, see the [**Testing Documentation**](docs/testing.md).
+
+---
+
+For all other information, please explore the [**AsioScan Documentation Hub**](docs/index.md).
 
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ asioscan scanme.nmap.org -p 1-10000 -c 500 -t 200
 * `-p, --ports` : Ports to scan (e.g., `80`, `22,80,443`, `1-1024`).
 * `-c, --concurrency` : Maximum concurrent async connections (default: `200`).
 * `-t, --timeout` : Per-port TCP connection timeout in milliseconds (default: `500`).
-* `-q, --quiet` : Script-friendly minimum output showing only open ports.
+* `-o, --output` : Write normal text results to a specific file.
 * `--oX, --output-xml` : Write structured XML output to a file for automation.
+* `-v, --verbose` : Show extended detail per port (latency, reasons).
+* `-q, --quiet` : Script-friendly minimum output showing only open ports.
+* `--summary` : Show only the final scan summary statistics.
 
 ### Example Output
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ For more details on the testing framework and test organization, see the [**Test
 
 ---
 
-For all other information, please explore the [**AsioScan Documentation Hub**](docs/index.md).
+## Documentation Hub
+
+For all other information, including advanced usage, architecture breakdowns, and pre-release roadmaps, please explore the [**AsioScan Documentation Hub**](docs/index.md).
 
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -4,20 +4,21 @@ This guide provides instructions for compiling AsioScan across Windows, macOS, a
 
 ## Prerequisites
 
-To build AsioScan, your system must have the following tools installed:
+To build AsioScan natively, your system must have the following tools installed:
 
-* **C++ Compiler**: A compiler supporting C++20 (e.g., GCC 10+, Clang 10+, or MSVC 2019+).
-* **CMake**: Version 3.16 or newer.
+* **C++ Compiler**: A modern compiler supporting C++20 (e.g., GCC 10+, Clang 10+, or MSVC 2019+).
+* **CMake**: Version 3.20 or newer (Required for `CMakePresets.json` support).
 
 ### Dependency Management
 
-The build system automatically fetches and builds the following internal dependencies using CMake's `FetchContent` module, so you do **not** need to install them manually:
+The build system automatically fetches and builds the following internal dependencies using CMake's `FetchContent` module. You do **not** need to install them manually:
+* **Standalone Asio** (for cross-platform networking)
 * **CLI11** (for command-line argument parsing)
-* **Catch2** (for unit testing)
+* **Catch2 v3** (for unit testing)
 
 ---
 
-## Installing Prerequisites by Platform
+## Installing Toolchains by Platform
 
 ### Linux (Debian/Ubuntu)
 ```bash
@@ -36,72 +37,84 @@ brew install cmake
 
 ---
 
-## Configuring and Building
+## Configuring and Building (Using CMake Presets)
 
-1. **Clone the repository:**
-   ```bash
-   git clone https://github.com/trystanhenriques/AsioScan.git
-   cd AsioScan
-   ```
+AsioScan ships with a unified `CMakePresets.json` file. This is the recommended way to build the project, as it automatically aligns generators, build types, and output behaviors across all operating systems.
 
-2. **Generate the build files using CMake:**
-   We recommend performing an out-of-source build by creating a `build` directory. 
-   
-   *For Linux/macOS:*
-   ```bash
-   mkdir build && cd build
-   cmake -DCMAKE_BUILD_TYPE=Release ..
-   ```
+**1. Clone the repository:**
+```bash
+git clone https://github.com/trystanhenriques/AsioScan.git
+cd AsioScan
+```
 
-   *For Windows:*
-   ```powershell
-   mkdir build && cd build
-   cmake ..
-   ```
+**2. Configure the project:**
+Choose the preset that matches your operating system:
+* `ubuntu-latest` (Uses Unix Makefiles)
+* `macos-latest` (Uses Unix Makefiles)
+* `windows-latest` (Uses Visual Studio 17 2022)
 
-3. **Compile the project:**
-   ```bash
-   cmake --build . --config Release
-   ```
+```bash
+# Example for Linux
+cmake --preset ubuntu-latest
+```
+
+**3. Compile the project:**
+This will automatically launch the build process targeting a `Release` configuration.
+```bash
+# Example for Linux
+cmake --build --preset ubuntu-latest
+```
 
 ---
 
 ## Running the Executable
 
-Once the build completes, the executable will be located in the build directory.
+Once the build completes, the executable will be deposited in the `build/` directory structure. 
 
 **Linux / macOS:**
 ```bash
-./asioscan --help
+./build/asioscan --help
 ```
 
 **Windows:**
-Depending on your generator, it may be placed inside a `Release` subdirectory:
+Because Windows uses a multi-config generator (Visual Studio), the binary is placed inside a `Release` subdirectory:
 ```powershell
-.\Release\asioscan.exe --help
+.\build\Release\asioscan.exe --help
 ```
 
 ---
 
 ## Running the Tests
 
-AsioScan includes a thorough suite of unit tests built using **Catch2**. The test executable (`asioscan_tests`) is built alongside the main application. 
+AsioScan includes a thorough suite of unit tests built using **Catch2**. 
 
-You can run the entire test suite heavily integrated with CMake's testing tool, `ctest`:
+You can run the entire test suite directly through CMake's testing tool, `ctest`, using the same preset:
 
 ```bash
-# From inside your build directory
-ctest --output-on-failure --build-config Release
+ctest --preset ubuntu-latest
 ```
+*(Note: Output on failure is automatically enabled via the preset).*
 
 Alternatively, you can invoke the Catch2 test runner directly for more granular control (like running specific tags):
 
 **Linux / macOS:**
 ```bash
-./tests/asioscan_tests
-./tests/asioscan_tests [cli]
+./build/tests/asioscan_tests [cli]
 ```
 
 **Windows:**
 ```powershell
-.\tests\Release\asioscan_tests.exe
+.\build\tests\Release\asioscan_tests.exe [xml]
+```
+
+---
+
+## Custom / Manual Builds
+
+If you prefer not to use presets, you can always build the project manually using standard CMake commands:
+
+```bash
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build . --config Release
+ctest --output-on-failure -C Release

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -71,3 +71,10 @@ The tests are physically separated from the main source code and reside in the `
 
 To provide reliable CI/CD and local development execution, the vast majority of AsioScan's tests are completely deterministic. 
 For example, the formatter and CLI tests do not access the live network. They test internal parsing rules and string generation using mocked inputs, ensuring that a test passing on Linux will also pass flawlessly on Windows.
+
+---
+
+## Continuous Integration (CI)
+
+AsioScan features a rigorous, multi-platform **GitHub Actions CI** matrix targeting Ubuntu, Windows, and macOS endpoints. 
+Each pull request and push to the repository seamlessly provisions the latest CMake Presets environment, builds the solution, and executes `ctest` targeting 100% pass coverage to guarantee the integrity of the project before a release.


### PR DESCRIPTION
This pull request significantly improves the documentation for AsioScan, focusing on onboarding, build instructions, testing, and CI/CD clarity. The README and supporting docs are rewritten for better usability, with clearer quick-start guides, CLI previews, and explicit build/test instructions using CMake presets. The documentation now also highlights the CI pipeline and provides direct references to advanced guides.

**Major documentation improvements:**

*README.md* enhancements:
- Rewrote the introduction for clarity and added a CI status badge for immediate project health visibility.
- Added a "Quick Start" section with simplified usage instructions, CLI options preview, and links to detailed CLI and architecture docs.
- Expanded build and test instructions, emphasizing CMake presets and automated dependency management.

*Build and test documentation* updates:
- Updated `docs/build.md` to require CMake 3.20+, clarify toolchain setup, and provide step-by-step build/test instructions using CMake presets for all platforms. Added a section for manual builds. [[1]](diffhunk://#diff-43453f510556d352276e897e137cb103b3bbca24acb6cba33208d4887b2e3c77L7-R21) [[2]](diffhunk://#diff-43453f510556d352276e897e137cb103b3bbca24acb6cba33208d4887b2e3c77L39-R120)
- Improved test documentation in `docs/testing.md`, detailing the CI pipeline and how tests are executed on each platform using GitHub Actions.

These changes make it much easier for new users and contributors to get started, ensure consistent builds, and clarify the project's automated quality controls.